### PR TITLE
Fixed typo in aftership in node

### DIFF
--- a/aftership.js
+++ b/aftership.js
@@ -90,7 +90,7 @@ module.exports = function(RED) {
 		var service = services[n.service]
 
 		self.on('input', function(msg) {
-			var slug = msg.payload.topic
+			var slug = msg.topic
 			var tracking_number = msg.payload
 
 			if (!slug) self.error('Topic: No carrier specified (dhl, ups, ...)')


### PR DESCRIPTION
Payload cannot be an object and a string at the same time. Based on the code for the AftershipGet node, I think this is what you meant.

Can you help me fix this and bump the version in NPM?

Thanks!